### PR TITLE
Add fetch-photos functionality to API and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,44 @@ pnpm verify-places abc123-def456-789
 - `generatedPlaceId`: UUID of a single generated place to verify
 - `scoreBump`: Score increase for verified places (default: 2)
 
+### Fetch Photos for Places
+
+Fetch photos for places that don't have any yet. Tries Wikimedia Commons first (free), then falls back to Google Places API:
+
+```bash
+pnpm fetch-photos [--minScore=<number>] [--limit=<number>]
+```
+
+**What it does**:
+
+1. Finds places without photos (`photos_fetched_at` is null)
+2. Optionally filters by minimum score
+3. Tries Wikimedia Commons API first (free, uses place name + coordinates + OSM ID)
+4. Falls back to Google Places API if no Wikimedia photos found
+5. Saves up to 5 photos per place, marks first as primary
+6. Sets `photos_fetched_at` timestamp to prevent refetching
+
+**Examples**:
+
+```bash
+# Fetch photos for all places without photos
+pnpm fetch-photos
+
+# Fetch photos only for places with score >= 5
+pnpm fetch-photos --minScore 5
+
+# Fetch photos for first 50 places with score >= 5
+pnpm fetch-photos --minScore 5 --limit 50
+
+# Fetch photos for first 10 places (any score)
+pnpm fetch-photos --limit 10
+```
+
+**Parameters**:
+
+- `--minScore`: Optional. Only fetch photos for places with score >= minScore
+- `--limit`: Optional. Maximum number of places to process
+
 ## Data Enhancement System
 
 The application includes a comprehensive system for enhancing place data with information from multiple sources:
@@ -359,6 +397,7 @@ The API provides endpoints for analyzing places. Full interactive documentation 
 - **POST `/api/places/{placeId}/analyze-wikipedia`**: Analyze a place's Wikipedia page
 - **POST `/api/urls/analyze`**: Analyze URLs and extract nature places
 - **POST `/api/places/verify`**: Verify generated places and create/update real places in OSM
+- **POST `/api/places/fetch-photos`**: Fetch photos for places that don't have any yet
 - **POST `/test`**: Test endpoint to verify API key authentication
 
 **Rate Limits**:
@@ -410,6 +449,7 @@ REDDIT_CLIENT_SECRET=your_reddit_client_secret
 | `analyze-place-wikipedia`     | Analyze a place's Wikipedia     | `pnpm analyze-place-wikipedia <place-id>`                |
 | `analyze-urls`                | Analyze URLs and extract places | `pnpm analyze-urls <url1> [url2] ...`                    |
 | `verify-places`               | Verify generated places in OSM  | `pnpm verify-places <sourceId> [scoreBump]`              |
+| `fetch-photos`                | Fetch photos for places         | `pnpm fetch-photos [--minScore=N] [--limit=N]`           |
 | `recalculate-scores`          | Recalculate place scores        | `pnpm recalculate-scores`                                |
 | `migrate-place-types`         | Migrate place types             | `pnpm migrate-place-types`                               |
 | `generate-types`              | Generate DB types               | `pnpm generate-types`                                    |

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "analyze-place-wikipedia": "ts-node src/scripts/analyze-place-wikipedia.ts",
     "analyze-urls": "ts-node src/scripts/analyze-urls.ts",
     "verify-places": "ts-node src/scripts/verify-places.ts",
+    "fetch-photos": "ts-node src/scripts/fetch-photos.ts",
     "clear-osm-cache": "./clear-osm-cache.sh",
     "clear-overture-cache": "./clear-overture-cache.sh",
     "generate-types": "supabase gen types typescript --project-id ydtttobvqajzglvdcqas > src/types/database.ts"

--- a/src/controllers/photo.controller.ts
+++ b/src/controllers/photo.controller.ts
@@ -1,0 +1,123 @@
+import { Request, Response } from 'express'
+import { supabase } from '../services/supabase.service'
+import { photoFetcherService } from '../services/photo-fetcher.service'
+import { Place } from '../db/places'
+
+export interface FetchPhotosResponse {
+  results: Array<{
+    placeId: string
+    placeName: string
+    success: boolean
+    photosFound: number
+    source: 'wikimedia' | 'google_places' | 'none'
+    error?: string
+  }>
+  totalProcessed: number
+  totalSuccess: number
+  totalPhotosFound: number
+}
+
+/**
+ * Fetch photos for places that don't have any yet
+ * Filters by minimum score if provided
+ */
+export async function fetchPhotos(
+  req: Request,
+  res: Response<FetchPhotosResponse | { error: string }>,
+): Promise<void> {
+  try {
+    const minScore = req.body.minScore ? Number(req.body.minScore) : undefined
+    const limit = req.body.limit ? Number(req.body.limit) : undefined
+
+    if (minScore !== undefined && (isNaN(minScore) || minScore < 0)) {
+      res.status(400).json({ error: 'minScore must be a non-negative number' })
+      return
+    }
+
+    if (limit !== undefined && (isNaN(limit) || limit < 1)) {
+      res.status(400).json({ error: 'limit must be a positive number' })
+      return
+    }
+
+    console.log(`\n📸 Starting photo fetch process`)
+    if (minScore !== undefined) {
+      console.log(`📊 Minimum score filter: ${minScore}`)
+    }
+    if (limit !== undefined) {
+      console.log(`🔢 Limit: ${limit} places`)
+    }
+
+    // Get places without photos
+    let query = supabase
+      .from('places')
+      .select('*')
+      .is('photos_fetched_at', null) // Places that haven't had photos fetched yet
+
+    if (minScore !== undefined) {
+      query = query.gte('score', minScore)
+    }
+
+    // Order by score descending to prioritize higher-scored places
+    query = query.order('score', { ascending: false })
+
+    if (limit !== undefined) {
+      query = query.limit(limit)
+    }
+
+    const { data: placesToProcess, error: queryError } = await query
+
+    if (queryError) {
+      console.error('❌ Error fetching places:', queryError)
+      res.status(500).json({ error: `Database error: ${queryError.message}` })
+      return
+    }
+
+    if (!placesToProcess || placesToProcess.length === 0) {
+      res.status(200).json({
+        results: [],
+        totalProcessed: 0,
+        totalSuccess: 0,
+        totalPhotosFound: 0,
+      })
+      return
+    }
+
+    console.log(`📋 Found ${placesToProcess.length} places to process`)
+
+    const results: FetchPhotosResponse['results'] = []
+
+    // Process places one by one with delay
+    for (let i = 0; i < placesToProcess.length; i++) {
+      const place = placesToProcess[i] as Place
+      console.log(`\n📍 Processing place ${i + 1}/${placesToProcess.length}: ${place.name}`)
+
+      const result = await photoFetcherService.fetchPhotosForPlace(place)
+      results.push(result)
+
+      // Add delay between requests (except for the last one)
+      if (i < placesToProcess.length - 1) {
+        await photoFetcherService.delay()
+      }
+    }
+
+    const totalSuccess = results.filter((r) => r.success).length
+    const totalPhotosFound = results.reduce((sum, r) => sum + r.photosFound, 0)
+
+    console.log(`\n✅ Photo fetch complete!`)
+    console.log(`📊 Processed: ${results.length}`)
+    console.log(`✅ Success: ${totalSuccess}`)
+    console.log(`📸 Total photos found: ${totalPhotosFound}`)
+
+    res.status(200).json({
+      results,
+      totalProcessed: results.length,
+      totalSuccess,
+      totalPhotosFound,
+    })
+  } catch (error) {
+    console.error('❌ Error in fetchPhotos:', error)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    res.status(500).json({ error: `Internal server error: ${errorMessage}` })
+  }
+}
+

--- a/src/db/place-photos.ts
+++ b/src/db/place-photos.ts
@@ -1,0 +1,75 @@
+import { PostgrestResponse, PostgrestSingleResponse } from '@supabase/supabase-js'
+import { supabase } from '../services/supabase.service'
+import { Tables } from '../types/database'
+
+export type PlacePhoto = Tables<'place_photos'>
+
+export interface CreatePlacePhotoInput {
+  place_id: string
+  source: 'wikimedia' | 'google_places'
+  url: string
+  attribution?: string | null
+  is_primary?: boolean
+}
+
+/**
+ * Get all photos for a place
+ */
+export async function getPlacePhotos(placeId: string): Promise<PostgrestResponse<PlacePhoto>> {
+  return supabase
+    .from('place_photos')
+    .select('*')
+    .eq('place_id', placeId)
+    .order('is_primary', { ascending: false })
+    .order('created_at', { ascending: true })
+}
+
+/**
+ * Get primary photo for a place
+ */
+export async function getPrimaryPhoto(placeId: string): Promise<PostgrestSingleResponse<PlacePhoto>> {
+  return supabase.from('place_photos').select('*').eq('place_id', placeId).eq('is_primary', true).single()
+}
+
+/**
+ * Create a new photo for a place
+ */
+export async function createPlacePhoto(photo: CreatePlacePhotoInput): Promise<PostgrestSingleResponse<PlacePhoto>> {
+  return supabase.from('place_photos').insert(photo).select().single()
+}
+
+/**
+ * Create multiple photos for a place in batch
+ */
+export async function createPlacePhotos(photos: CreatePlacePhotoInput[]): Promise<PostgrestResponse<PlacePhoto>> {
+  if (photos.length === 0) {
+    return { data: [], error: null } as unknown as PostgrestResponse<PlacePhoto>
+  }
+
+  return supabase.from('place_photos').insert(photos).select()
+}
+
+/**
+ * Set a photo as primary (and unset others)
+ */
+export async function setPrimaryPhoto(placeId: string, photoId: string): Promise<PostgrestResponse<PlacePhoto>> {
+  // First, unset all primary photos for this place
+  await supabase.from('place_photos').update({ is_primary: false }).eq('place_id', placeId).eq('is_primary', true)
+
+  // Then set the new primary photo
+  return supabase.from('place_photos').update({ is_primary: true }).eq('id', photoId).eq('place_id', placeId).select()
+}
+
+/**
+ * Check if place has any photos
+ */
+export async function hasPlacePhotos(placeId: string): Promise<boolean> {
+  const { data, error } = await supabase.from('place_photos').select('id').eq('place_id', placeId).limit(1)
+
+  if (error) {
+    console.error('❌ Error checking place photos:', error)
+    return false
+  }
+
+  return (data?.length || 0) > 0
+}

--- a/src/db/places-with-photos.ts
+++ b/src/db/places-with-photos.ts
@@ -1,0 +1,77 @@
+import { supabase } from '../services/supabase.service'
+import { PlacePhoto } from './place-photos'
+import { PlaceWithPhotos } from './places'
+
+/**
+ * Get multiple places by IDs with photos included (using nested select for efficiency)
+ */
+export async function getPlacesByIdsWithPhotos(ids: string[]): Promise<PlaceWithPhotos[]> {
+  if (ids.length === 0) {
+    return []
+  }
+
+  const { data: places, error } = await supabase.from('places').select('*, place_photos(*)').in('id', ids)
+
+  if (error || !places) {
+    console.error('Error fetching places with photos:', error)
+    return []
+  }
+
+  return places as PlaceWithPhotos[]
+}
+
+/**
+ * Fetch photos for multiple place IDs and return a map of place_id -> photos[]
+ * Useful for attaching photos to search results from database functions
+ */
+export async function getPhotosForPlaceIds(placeIds: string[]): Promise<Map<string, PlacePhoto[]>> {
+  if (placeIds.length === 0) {
+    return new Map()
+  }
+
+  const { data: photos, error } = await supabase
+    .from('place_photos')
+    .select('*')
+    .in('place_id', placeIds)
+    .order('is_primary', { ascending: false })
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('Error fetching photos:', error)
+    return new Map()
+  }
+
+  // Group photos by place_id
+  const photosByPlaceId = new Map<string, PlacePhoto[]>()
+  if (photos) {
+    for (const photo of photos) {
+      const placeId = photo.place_id
+      if (!photosByPlaceId.has(placeId)) {
+        photosByPlaceId.set(placeId, [])
+      }
+      photosByPlaceId.get(placeId)!.push(photo)
+    }
+  }
+
+  return photosByPlaceId
+}
+
+/**
+ * Attach photos to places fetched from database functions (like search_places_by_location)
+ * This is useful when you get places from PostgreSQL functions that don't include photos
+ */
+export async function attachPhotosToPlaces<T extends { id: string }>(
+  places: T[],
+): Promise<Array<T & { photos?: PlacePhoto[] }>> {
+  if (places.length === 0) {
+    return []
+  }
+
+  const placeIds = places.map((p) => p.id)
+  const photosMap = await getPhotosForPlaceIds(placeIds)
+
+  return places.map((place) => ({
+    ...place,
+    photos: photosMap.get(place.id) || [],
+  }))
+}

--- a/src/db/places.ts
+++ b/src/db/places.ts
@@ -1,11 +1,23 @@
 import { PostgrestSingleResponse } from '@supabase/supabase-js'
 import { supabase } from '../services/supabase.service'
 import { Tables } from '../types/database'
+import { PlacePhoto } from './place-photos'
 
 export type Place = Tables<'places'>
 
+export interface PlaceWithPhotos extends Place {
+  place_photos?: PlacePhoto[]
+}
+
 export async function getPlaceById(id: string): Promise<PostgrestSingleResponse<Place>> {
   return supabase.from('places').select('*').eq('id', id).single()
+}
+
+/**
+ * Get a place by ID with photos included (using nested select for efficiency)
+ */
+export async function getPlaceByIdWithPhotos(id: string): Promise<PostgrestSingleResponse<PlaceWithPhotos>> {
+  return supabase.from('places').select('*, place_photos(*)').eq('id', id).single()
 }
 
 export async function updatePlace(id: string, updates: Partial<Place>): Promise<PostgrestSingleResponse<Place>> {

--- a/src/scripts/fetch-photos.ts
+++ b/src/scripts/fetch-photos.ts
@@ -1,0 +1,148 @@
+import 'dotenv/config'
+import { supabase } from '../services/supabase.service'
+import { photoFetcherService } from '../services/photo-fetcher.service'
+import { Place } from '../db/places'
+
+interface ProcessStats {
+  processedCount: number
+  successCount: number
+  errorCount: number
+  photosFound: number
+}
+
+class PhotoFetcher {
+  public readonly stats: ProcessStats
+
+  constructor() {
+    this.stats = {
+      processedCount: 0,
+      successCount: 0,
+      errorCount: 0,
+      photosFound: 0,
+    }
+  }
+
+  private printProgress(): void {
+    console.log(`\n📊 Progress:`)
+    console.log(`   Processed: ${this.stats.processedCount}`)
+    console.log(`   Success: ${this.stats.successCount}`)
+    console.log(`   Errors: ${this.stats.errorCount}`)
+    console.log(`   Photos found: ${this.stats.photosFound}`)
+  }
+
+  public async fetchPhotosForPlaces(minScore?: number, limit?: number): Promise<void> {
+    console.log(`\n📸 Starting photo fetch process`)
+    if (minScore !== undefined) {
+      console.log(`📊 Minimum score filter: ${minScore}`)
+    }
+    if (limit !== undefined) {
+      console.log(`🔢 Limit: ${limit} places`)
+    }
+
+    // Get places without photos
+    let query = supabase
+      .from('places')
+      .select('*')
+      .is('photos_fetched_at', null) // Places that haven't had photos fetched yet
+
+    if (minScore !== undefined) {
+      query = query.gte('score', minScore)
+    }
+
+    // Order by score descending to prioritize higher-scored places
+    query = query.order('score', { ascending: false })
+
+    if (limit !== undefined) {
+      query = query.limit(limit)
+    }
+
+    const { data: placesToProcess, error: queryError } = await query
+
+    if (queryError) {
+      console.error('❌ Error fetching places:', queryError)
+      throw queryError
+    }
+
+    if (!placesToProcess || placesToProcess.length === 0) {
+      console.log('✅ No places to process!')
+      return
+    }
+
+    console.log(`📋 Found ${placesToProcess.length} places to process`)
+
+    // Process places one by one with delay
+    for (let i = 0; i < placesToProcess.length; i++) {
+      const place = placesToProcess[i] as Place
+      console.log(`\n📍 Processing place ${i + 1}/${placesToProcess.length}: ${place.name}`)
+
+      try {
+        const result = await photoFetcherService.fetchPhotosForPlace(place)
+        this.stats.processedCount++
+
+        if (result.success) {
+          this.stats.successCount++
+          this.stats.photosFound += result.photosFound
+        } else {
+          this.stats.errorCount++
+        }
+
+        // Print progress every 10 places
+        if ((i + 1) % 10 === 0) {
+          this.printProgress()
+        }
+
+        // Add delay between requests (except for the last one)
+        if (i < placesToProcess.length - 1) {
+          await photoFetcherService.delay()
+        }
+      } catch (error) {
+        this.stats.processedCount++
+        this.stats.errorCount++
+        console.error(`❌ Error processing place ${place.name}:`, error)
+      }
+    }
+
+    // Final summary
+    console.log(`\n✅ Photo fetch complete!`)
+    this.printProgress()
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  let minScore: number | undefined
+  let limit: number | undefined
+
+  // Parse command line arguments
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--minScore' && i + 1 < args.length) {
+      minScore = Number(args[i + 1])
+      if (isNaN(minScore) || minScore < 0) {
+        console.error('❌ minScore must be a non-negative number')
+        process.exit(1)
+      }
+      i++
+    } else if (args[i] === '--limit' && i + 1 < args.length) {
+      limit = Number(args[i + 1])
+      if (isNaN(limit) || limit < 1) {
+        console.error('❌ limit must be a positive number')
+        process.exit(1)
+      }
+      i++
+    }
+  }
+
+  const fetcher = new PhotoFetcher()
+
+  try {
+    await fetcher.fetchPhotosForPlaces(minScore, limit)
+  } catch (error) {
+    console.error('❌ Fatal error:', error)
+    process.exit(1)
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+

--- a/src/services/google-places-photos.service.ts
+++ b/src/services/google-places-photos.service.ts
@@ -1,0 +1,177 @@
+export interface GooglePlacesPhoto {
+  url: string
+  attribution: string
+  width?: number
+  height?: number
+}
+
+export class GooglePlacesPhotosService {
+  private readonly apiKey: string
+
+  constructor() {
+    if (!process.env.GOOGLE_PLACES_API_KEY) {
+      throw new Error('GOOGLE_PLACES_API_KEY environment variable is required')
+    }
+    this.apiKey = process.env.GOOGLE_PLACES_API_KEY
+  }
+
+  /**
+   * Search for a place using Google Places API Text Search
+   * Returns place_id if found
+   */
+  public async findPlaceId(
+    placeName: string,
+    latitude: number | null,
+    longitude: number | null,
+  ): Promise<string | null> {
+    try {
+      console.log(`🔍 Searching Google Places for: ${placeName}`)
+
+      const baseUrl = 'https://places.googleapis.com/v1/places:searchText'
+      const body: any = {
+        textQuery: placeName,
+        maxResultCount: 1,
+      }
+
+      // Add location bias if coordinates available
+      if (latitude !== null && longitude !== null) {
+        body.locationBias = {
+          circle: {
+            center: {
+              latitude,
+              longitude,
+            },
+            radius: 5000.0, // 5km radius
+          },
+        }
+      }
+
+      const response = await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': this.apiKey,
+          'X-Goog-FieldMask': 'places.id,places.displayName',
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10000),
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Google Places API error: ${response.status} - ${errorText}`)
+      }
+
+      const data = (await response.json()) as {
+        places?: Array<{
+          id: string
+          displayName?: { text: string }
+        }>
+      }
+
+      if (data.places && data.places.length > 0) {
+        const placeId = data.places[0].id
+        console.log(`✅ Found Google Place ID: ${placeId}`)
+        return placeId
+      }
+
+      console.log(`❌ No Google Place found for: ${placeName}`)
+      return null
+    } catch (error) {
+      console.error(`❌ Error searching Google Places:`, error)
+      return null
+    }
+  }
+
+  /**
+   * Get photos for a place using Google Places API
+   */
+  public async getPlacePhotos(placeId: string): Promise<GooglePlacesPhoto[]> {
+    try {
+      console.log(`📸 Fetching photos for Google Place ID: ${placeId}`)
+
+      const baseUrl = `https://places.googleapis.com/v1/places/${placeId}`
+
+      const response = await fetch(baseUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': this.apiKey,
+          'X-Goog-FieldMask': 'photos',
+        },
+        signal: AbortSignal.timeout(10000),
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Google Places API error: ${response.status} - ${errorText}`)
+      }
+
+      const data = (await response.json()) as {
+        photos?: Array<{
+          name: string
+          widthPx?: number
+          heightPx?: number
+          authorAttributions?: Array<{
+            displayName?: string
+            uri?: string
+          }>
+        }>
+      }
+
+      if (!data.photos || data.photos.length === 0) {
+        console.log(`❌ No photos found for Google Place ID: ${placeId}`)
+        return []
+      }
+
+      const photos: GooglePlacesPhoto[] = []
+
+      // Get up to 5 photos
+      const photosToFetch = data.photos.slice(0, 5)
+
+      for (const photo of photosToFetch) {
+        // Build photo URL using the photo name
+        // Format: https://places.googleapis.com/v1/{photo.name}/media?maxHeightPx=800&maxWidthPx=800&key={API_KEY}
+        const photoUrl = `https://places.googleapis.com/v1/${photo.name}/media?maxHeightPx=800&maxWidthPx=800&key=${this.apiKey}`
+
+        // Build attribution
+        const author = photo.authorAttributions?.[0]
+        const attribution = author?.displayName
+          ? `Photo by ${author.displayName} via Google Places`
+          : 'Photo via Google Places'
+
+        photos.push({
+          url: photoUrl,
+          attribution,
+          width: photo.widthPx,
+          height: photo.heightPx,
+        })
+      }
+
+      console.log(`✅ Found ${photos.length} photos from Google Places`)
+      return photos
+    } catch (error) {
+      console.error(`❌ Error fetching Google Places photos:`, error)
+      return []
+    }
+  }
+
+  /**
+   * Search for photos of a place by name and coordinates
+   */
+  public async searchPlacePhotos(
+    placeName: string,
+    latitude: number | null,
+    longitude: number | null,
+  ): Promise<GooglePlacesPhoto[]> {
+    const placeId = await this.findPlaceId(placeName, latitude, longitude)
+    if (!placeId) {
+      return []
+    }
+
+    return await this.getPlacePhotos(placeId)
+  }
+}
+
+export const googlePlacesPhotosService = new GooglePlacesPhotosService()
+

--- a/src/services/photo-fetcher.service.ts
+++ b/src/services/photo-fetcher.service.ts
@@ -1,0 +1,167 @@
+import { calculateGeometryCenter } from '../utils/common'
+import { createPlacePhotos, setPrimaryPhoto } from '../db/place-photos'
+import { updatePlace } from '../db/places'
+import { googlePlacesPhotosService, GooglePlacesPhoto } from './google-places-photos.service'
+import { wikimediaPhotosService, WikimediaPhoto } from './wikimedia-photos.service'
+import { Place } from '../db/places'
+
+export interface PhotoFetchResult {
+  placeId: string
+  placeName: string
+  success: boolean
+  photosFound: number
+  source: 'wikimedia' | 'google_places' | 'none'
+  error?: string
+}
+
+export class PhotoFetcherService {
+  /**
+   * Fetch photos for a place, trying Wikimedia first, then Google Places
+   */
+  public async fetchPhotosForPlace(place: Place): Promise<PhotoFetchResult> {
+    const result: PhotoFetchResult = {
+      placeId: place.id,
+      placeName: place.name || 'Unknown',
+      success: false,
+      photosFound: 0,
+      source: 'none',
+    }
+
+    try {
+      // Get coordinates from geometry or location
+      const center = calculateGeometryCenter(place.geometry)
+      const latitude = center?.lat || null
+      const longitude = center?.lon || null
+
+      if (!place.name) {
+        result.error = 'Place has no name'
+        return result
+      }
+
+      console.log(`\n📸 Fetching photos for: ${place.name}`)
+      if (latitude !== null && longitude !== null) {
+        console.log(`📍 Location: ${latitude}, ${longitude}`)
+      }
+
+      // Try Wikimedia first (free)
+      console.log(`1️⃣ Trying Wikimedia Commons...`)
+      const wikimediaPhotos = await wikimediaPhotosService.searchPlacePhotos(
+        place.name,
+        latitude,
+        longitude,
+        place.osm_id || null,
+      )
+
+      if (wikimediaPhotos.length > 0) {
+        console.log(`✅ Found ${wikimediaPhotos.length} photos from Wikimedia Commons`)
+        await this.savePhotos(place.id, wikimediaPhotos, 'wikimedia')
+        result.success = true
+        result.photosFound = wikimediaPhotos.length
+        result.source = 'wikimedia'
+        await this.markPhotosFetched(place.id)
+        return result
+      }
+
+      // Fallback to Google Places
+      console.log(`2️⃣ No Wikimedia photos found, trying Google Places...`)
+      if (latitude === null || longitude === null) {
+        console.log(`⚠️ No coordinates available, skipping Google Places search`)
+        result.error = 'No coordinates available for Google Places search'
+        await this.markPhotosFetched(place.id)
+        return result
+      }
+
+      const googlePhotos = await googlePlacesPhotosService.searchPlacePhotos(
+        place.name,
+        latitude,
+        longitude,
+      )
+
+      if (googlePhotos.length > 0) {
+        console.log(`✅ Found ${googlePhotos.length} photos from Google Places`)
+        await this.savePhotos(place.id, googlePhotos, 'google_places')
+        result.success = true
+        result.photosFound = googlePhotos.length
+        result.source = 'google_places'
+        await this.markPhotosFetched(place.id)
+        return result
+      }
+
+      console.log(`❌ No photos found from any source`)
+      result.error = 'No photos found'
+      await this.markPhotosFetched(place.id)
+      return result
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      console.error(`❌ Error fetching photos:`, errorMessage)
+      result.error = errorMessage
+      await this.markPhotosFetched(place.id)
+      return result
+    }
+  }
+
+  /**
+   * Save photos to database and set the first one as primary
+   */
+  private async savePhotos(
+    placeId: string,
+    photos: WikimediaPhoto[] | GooglePlacesPhoto[],
+    source: 'wikimedia' | 'google_places',
+  ): Promise<void> {
+    if (photos.length === 0) {
+      return
+    }
+
+    try {
+      // Convert to database format
+      const photosToInsert = photos.map((photo, index) => ({
+        place_id: placeId,
+        source,
+        url: photo.url,
+        attribution: photo.attribution,
+        is_primary: index === 0, // First photo is primary
+      }))
+
+      const { data, error } = await createPlacePhotos(photosToInsert)
+
+      if (error) {
+        console.error(`❌ Error saving photos:`, error)
+        throw error
+      }
+
+      console.log(`✅ Saved ${photosToInsert.length} photos to database`)
+
+      // Ensure first photo is marked as primary (in case of duplicates)
+      if (data && data.length > 0) {
+        await setPrimaryPhoto(placeId, data[0].id)
+      }
+    } catch (error) {
+      console.error(`❌ Error in savePhotos:`, error)
+      throw error
+    }
+  }
+
+  /**
+   * Mark that photos have been fetched for this place
+   */
+  private async markPhotosFetched(placeId: string): Promise<void> {
+    try {
+      await updatePlace(placeId, {
+        photos_fetched_at: new Date().toISOString(),
+      })
+    } catch (error) {
+      console.error(`❌ Error marking photos as fetched:`, error)
+      // Don't throw - this is not critical
+    }
+  }
+
+  /**
+   * Add delay between API requests (1 second as requested)
+   */
+  public async delay(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+}
+
+export const photoFetcherService = new PhotoFetcherService()
+

--- a/src/services/wikimedia-photos.service.ts
+++ b/src/services/wikimedia-photos.service.ts
@@ -1,0 +1,253 @@
+interface WikimediaSearchResult {
+  query: {
+    search: Array<{
+      title: string
+      pageid: number
+    }>
+  }
+}
+
+interface WikimediaPageResult {
+  query: {
+    pages: {
+      [key: string]: {
+        pageid: number
+        title: string
+        imageinfo?: Array<{
+          url: string
+          descriptionurl: string
+          extmetadata?: {
+            Artist?: { value: string }
+            Attribution?: { value: string }
+            LicenseShortName?: { value: string }
+            ImageDescription?: { value: string }
+          }
+          width?: number
+          height?: number
+        }>
+      }
+    }
+  }
+}
+
+export interface WikimediaPhoto {
+  url: string
+  attribution: string
+  width?: number
+  height?: number
+}
+
+export class WikimediaPhotosService {
+  /**
+   * Search for photos of a place using Wikimedia Commons API
+   * Uses place name, coordinates, and optionally OSM ID
+   */
+  public async searchPlacePhotos(
+    placeName: string,
+    latitude: number | null,
+    longitude: number | null,
+    osmId?: string | null,
+  ): Promise<WikimediaPhoto[]> {
+    try {
+      console.log(`🔍 Searching Wikimedia Commons for: ${placeName}`)
+
+      // Build search query
+      const searchQueries: string[] = [placeName]
+
+      // Add location-based search if coordinates available
+      if (latitude !== null && longitude !== null) {
+        // Search for nearby images using geosearch
+        const nearbyPhotos = await this.searchNearbyPhotos(latitude, longitude)
+        if (nearbyPhotos.length > 0) {
+          console.log(`✅ Found ${nearbyPhotos.length} nearby photos from geosearch`)
+          return nearbyPhotos
+        }
+      }
+
+      // Try searching by place name
+      const namePhotos = await this.searchByPlaceName(placeName, osmId)
+      if (namePhotos.length > 0) {
+        console.log(`✅ Found ${namePhotos.length} photos by name search`)
+        return namePhotos
+      }
+
+      console.log(`❌ No photos found for: ${placeName}`)
+      return []
+    } catch (error) {
+      console.error(`❌ Error searching Wikimedia Commons:`, error)
+      return []
+    }
+  }
+
+  /**
+   * Search for photos near coordinates using geosearch
+   */
+  private async searchNearbyPhotos(latitude: number, longitude: number): Promise<WikimediaPhoto[]> {
+    try {
+      const baseUrl = 'https://commons.wikimedia.org/w/api.php'
+      const params = new URLSearchParams({
+        action: 'query',
+        list: 'geosearch',
+        gscoord: `${latitude}|${longitude}`,
+        gsradius: '10000', // 10km radius
+        gslimit: '50',
+        format: 'json',
+        origin: '*',
+      })
+
+      const response = await fetch(`${baseUrl}?${params.toString()}`, {
+        headers: {
+          'User-Agent': 'empreinte-backend/1.0.0 (https://github.com/alexphiev/empreinte_backend)',
+        },
+        signal: AbortSignal.timeout(10000),
+      })
+
+      if (!response.ok) {
+        throw new Error(`Wikimedia API error: ${response.status}`)
+      }
+
+      const data = (await response.json()) as { query?: { geosearch?: Array<{ pageid: number }> } }
+
+      if (!data.query?.geosearch || data.query.geosearch.length === 0) {
+        return []
+      }
+
+      // Get image info for the found pages
+      const pageIds = data.query.geosearch.map((item) => item.pageid).join('|')
+      return await this.getImageInfo(pageIds)
+    } catch (error) {
+      console.error(`❌ Error in geosearch:`, error)
+      return []
+    }
+  }
+
+  /**
+   * Search for photos by place name
+   */
+  private async searchByPlaceName(placeName: string, osmId?: string | null): Promise<WikimediaPhoto[]> {
+    try {
+      const baseUrl = 'https://commons.wikimedia.org/w/api.php'
+
+      // Try multiple search strategies
+      const searchTerms = [placeName]
+
+      // Add OSM ID-based search if available
+      if (osmId) {
+        searchTerms.push(`Q${osmId}`) // Wikidata Q ID format (if OSM ID maps to Wikidata)
+      }
+
+      for (const searchTerm of searchTerms) {
+        const params = new URLSearchParams({
+          action: 'query',
+          list: 'search',
+          srsearch: searchTerm,
+          srnamespace: '6', // File namespace
+          srlimit: '20',
+          format: 'json',
+          origin: '*',
+        })
+
+        const response = await fetch(`${baseUrl}?${params.toString()}`, {
+          headers: {
+            'User-Agent': 'empreinte-backend/1.0.0 (https://github.com/alexphiev/empreinte_backend)',
+          },
+          signal: AbortSignal.timeout(10000),
+        })
+
+        if (!response.ok) {
+          continue
+        }
+
+        const data = (await response.json()) as WikimediaSearchResult
+
+        if (data.query?.search && data.query.search.length > 0) {
+          const pageIds = data.query.search.map((item) => item.pageid).join('|')
+          const photos = await this.getImageInfo(pageIds)
+          if (photos.length > 0) {
+            return photos
+          }
+        }
+      }
+
+      return []
+    } catch (error) {
+      console.error(`❌ Error searching by name:`, error)
+      return []
+    }
+  }
+
+  /**
+   * Get image information for given page IDs
+   */
+  private async getImageInfo(pageIds: string): Promise<WikimediaPhoto[]> {
+    try {
+      const baseUrl = 'https://commons.wikimedia.org/w/api.php'
+      const params = new URLSearchParams({
+        action: 'query',
+        pageids: pageIds,
+        prop: 'imageinfo',
+        iiprop: 'url|extmetadata|size',
+        iiurlwidth: '800', // Get medium resolution
+        format: 'json',
+        origin: '*',
+      })
+
+      const response = await fetch(`${baseUrl}?${params.toString()}`, {
+        headers: {
+          'User-Agent': 'empreinte-backend/1.0.0 (https://github.com/alexphiev/empreinte_backend)',
+        },
+        signal: AbortSignal.timeout(10000),
+      })
+
+      if (!response.ok) {
+        throw new Error(`Wikimedia API error: ${response.status}`)
+      }
+
+      const data = (await response.json()) as WikimediaPageResult
+
+      if (!data.query?.pages) {
+        return []
+      }
+
+      const photos: WikimediaPhoto[] = []
+
+      for (const page of Object.values(data.query.pages)) {
+        if (page.imageinfo && page.imageinfo.length > 0) {
+          const imageInfo = page.imageinfo[0]
+          const url = imageInfo.url
+
+          // Skip if not an image URL
+          if (!url || (!url.includes('.jpg') && !url.includes('.jpeg') && !url.includes('.png'))) {
+            continue
+          }
+
+          // Build attribution
+          const extmetadata = imageInfo.extmetadata || {}
+          const artist = extmetadata.Artist?.value || 'Unknown'
+          const license = extmetadata.LicenseShortName?.value || 'Unknown license'
+          const attribution = `Photo by ${artist}, ${license}`
+
+          photos.push({
+            url,
+            attribution,
+            width: imageInfo.width,
+            height: imageInfo.height,
+          })
+        }
+      }
+
+      // Sort by resolution (prefer higher resolution)
+      return photos.sort((a, b) => {
+        const aRes = (a.width || 0) * (a.height || 0)
+        const bRes = (b.width || 0) * (b.height || 0)
+        return bRes - aRes
+      })
+    } catch (error) {
+      console.error(`❌ Error getting image info:`, error)
+      return []
+    }
+  }
+}
+
+export const wikimediaPhotosService = new WikimediaPhotosService()
+

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -62,6 +62,47 @@ export type Database = {
           },
         ]
       }
+      place_photos: {
+        Row: {
+          attribution: string | null
+          created_at: string | null
+          id: string
+          is_primary: boolean | null
+          place_id: string
+          source: string
+          updated_at: string | null
+          url: string
+        }
+        Insert: {
+          attribution?: string | null
+          created_at?: string | null
+          id?: string
+          is_primary?: boolean | null
+          place_id: string
+          source: string
+          updated_at?: string | null
+          url: string
+        }
+        Update: {
+          attribution?: string | null
+          created_at?: string | null
+          id?: string
+          is_primary?: boolean | null
+          place_id?: string
+          source?: string
+          updated_at?: string | null
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "place_photos_place_id_fkey"
+            columns: ["place_id"]
+            isOneToOne: false
+            referencedRelation: "places"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       places: {
         Row: {
           country: string | null
@@ -77,6 +118,7 @@ export type Database = {
           metadata: Json | null
           name: string | null
           osm_id: string | null
+          photos_fetched_at: string | null
           reddit_data: Json | null
           reddit_generated: string | null
           region: string | null
@@ -110,6 +152,7 @@ export type Database = {
           metadata?: Json | null
           name?: string | null
           osm_id?: string | null
+          photos_fetched_at?: string | null
           reddit_data?: Json | null
           reddit_generated?: string | null
           region?: string | null
@@ -143,6 +186,7 @@ export type Database = {
           metadata?: Json | null
           name?: string | null
           osm_id?: string | null
+          photos_fetched_at?: string | null
           reddit_data?: Json | null
           reddit_generated?: string | null
           region?: string | null

--- a/supabase_schema_place_photos.sql
+++ b/supabase_schema_place_photos.sql
@@ -1,0 +1,36 @@
+-- Add photos_fetched_at column to places table
+ALTER TABLE places ADD COLUMN IF NOT EXISTS photos_fetched_at TIMESTAMPTZ;
+
+-- Create place_photos table
+CREATE TABLE IF NOT EXISTS place_photos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  place_id UUID NOT NULL REFERENCES places(id) ON DELETE CASCADE,
+  source TEXT NOT NULL CHECK (source IN ('wikimedia', 'google_places')),
+  url TEXT NOT NULL,
+  attribution TEXT,
+  is_primary BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_place_photos_place_id ON place_photos(place_id);
+CREATE INDEX IF NOT EXISTS idx_place_photos_is_primary ON place_photos(place_id, is_primary) WHERE is_primary = TRUE;
+CREATE INDEX IF NOT EXISTS idx_place_photos_source ON place_photos(source);
+
+-- Create unique constraint to prevent duplicate photos (same place + url)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_place_photos_unique ON place_photos(place_id, url);
+
+-- Add a trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_place_photos_updated_at ON place_photos;
+CREATE TRIGGER update_place_photos_updated_at BEFORE UPDATE ON place_photos
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+


### PR DESCRIPTION
- Introduced a new command `fetch-photos` to fetch images for places lacking photos, utilizing Wikimedia Commons and Google Places API as sources.
- Updated README.md with detailed usage instructions and examples for the new command.
- Added a new API endpoint `/api/places/fetch-photos` with Swagger documentation for fetching photos.
- Enhanced database types to include `place_photos` and updated `places` table to track when photos were fetched.
- Implemented a new function `getPlaceByIdWithPhotos` to retrieve places along with their associated photos.