### PR TITLE
Add fetch-ratings functionality to README, API, and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,47 @@ pnpm fetch-photos --limit 10
 - `--minScore`: Optional. Only fetch photos for places with score >= minScore
 - `--limit`: Optional. Maximum number of places to process
 
+### Fetch Ratings for Places
+
+Fetch ratings from Google Places API for places that need them:
+
+```bash
+pnpm fetch-ratings [--minScore=<number>] [--limit=<number>]
+```
+
+**What it does**:
+
+1. Finds places that haven't had ratings fetched yet, or were fetched more than 6 months ago
+2. Optionally filters by minimum score
+3. Uses existing Google Places ID if available, otherwise searches for it by name/coordinates
+4. Fetches rating and review count from Google Places API
+5. Stores Google Places ID for future use
+6. Sets `google_rating_fetched_at` timestamp to prevent refetching
+7. Adds +2 score bump when ratings are first collected (not on refresh)
+
+**Examples**:
+
+```bash
+# Fetch ratings for all places that need them
+pnpm fetch-ratings
+
+# Fetch ratings only for places with score >= 5
+pnpm fetch-ratings --minScore 5
+
+# Fetch ratings for first 50 places with score >= 5
+pnpm fetch-ratings --minScore 5 --limit 50
+
+# Fetch ratings for first 10 places (any score)
+pnpm fetch-ratings --limit 10
+```
+
+**Parameters**:
+
+- `--minScore`: Optional. Only fetch ratings for places with score >= minScore
+- `--limit`: Optional. Maximum number of places to process
+
+**Note**: Ratings are refreshed every 6 months. Places with ratings fetched less than 6 months ago will be skipped.
+
 ## Data Enhancement System
 
 The application includes a comprehensive system for enhancing place data with information from multiple sources:
@@ -398,6 +439,7 @@ The API provides endpoints for analyzing places. Full interactive documentation 
 - **POST `/api/urls/analyze`**: Analyze URLs and extract nature places
 - **POST `/api/places/verify`**: Verify generated places and create/update real places in OSM
 - **POST `/api/places/fetch-photos`**: Fetch photos for places that don't have any yet
+- **POST `/api/places/fetch-ratings`**: Fetch ratings from Google Places API for places that need them
 - **POST `/test`**: Test endpoint to verify API key authentication
 
 **Rate Limits**:
@@ -433,25 +475,29 @@ ALLOWED_ORIGINS=http://localhost:3000  # Comma-separated list
 # Reddit API (for enhancement)
 REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
+
+# Google Places API (for photos and ratings)
+GOOGLE_PLACES_API_KEY=your_google_places_api_key
 ```
 
 ## Scripts Summary
 
-| Script                        | Purpose                         | Usage                                                    |
-| ----------------------------- | ------------------------------- | -------------------------------------------------------- |
-| `fetch-osm-places`            | Fetch places from OpenStreetMap | `pnpm fetch-osm-places <dept> [--limit=N]`               |
-| `fetch-overture-places`       | Fetch places from Overture Maps | `pnpm fetch-overture-places`                             |
-| `fetch-french-regional-parks` | Import French regional parks    | `pnpm fetch-french-regional-parks [--force] [--limit=N]` |
-| `fetch-french-national-parks` | Import French national parks    | `pnpm fetch-french-national-parks [--force] [--limit=N]` |
-| `remove-places`               | Remove places by source         | `pnpm remove-places <source>`                            |
-| `enhance-places`              | Enhance place data with AI      | `pnpm enhance-places [list\|all\|<id>] [force]`          |
-| `analyze-place-website`       | Analyze a place's website       | `pnpm analyze-place-website <place-id>`                  |
-| `analyze-place-wikipedia`     | Analyze a place's Wikipedia     | `pnpm analyze-place-wikipedia <place-id>`                |
-| `analyze-urls`                | Analyze URLs and extract places | `pnpm analyze-urls <url1> [url2] ...`                    |
-| `verify-places`               | Verify generated places in OSM  | `pnpm verify-places <sourceId> [scoreBump]`              |
-| `fetch-photos`                | Fetch photos for places         | `pnpm fetch-photos [--minScore=N] [--limit=N]`           |
-| `recalculate-scores`          | Recalculate place scores        | `pnpm recalculate-scores`                                |
-| `migrate-place-types`         | Migrate place types             | `pnpm migrate-place-types`                               |
-| `generate-types`              | Generate DB types               | `pnpm generate-types`                                    |
-| `clear-osm-cache`             | Clear OSM cache                 | `pnpm clear-osm-cache`                                   |
-| `clear-overture-cache`        | Clear Overture cache            | `pnpm clear-overture-cache`                              |
+| Script                        | Purpose                          | Usage                                                    |
+| ----------------------------- | -------------------------------- | -------------------------------------------------------- |
+| `fetch-osm-places`            | Fetch places from OpenStreetMap  | `pnpm fetch-osm-places <dept> [--limit=N]`               |
+| `fetch-overture-places`       | Fetch places from Overture Maps  | `pnpm fetch-overture-places`                             |
+| `fetch-french-regional-parks` | Import French regional parks     | `pnpm fetch-french-regional-parks [--force] [--limit=N]` |
+| `fetch-french-national-parks` | Import French national parks     | `pnpm fetch-french-national-parks [--force] [--limit=N]` |
+| `remove-places`               | Remove places by source          | `pnpm remove-places <source>`                            |
+| `enhance-places`              | Enhance place data with AI       | `pnpm enhance-places [list\|all\|<id>] [force]`          |
+| `analyze-place-website`       | Analyze a place's website        | `pnpm analyze-place-website <place-id>`                  |
+| `analyze-place-wikipedia`     | Analyze a place's Wikipedia      | `pnpm analyze-place-wikipedia <place-id>`                |
+| `analyze-urls`                | Analyze URLs and extract places  | `pnpm analyze-urls <url1> [url2] ...`                    |
+| `verify-places`               | Verify generated places in OSM   | `pnpm verify-places <sourceId> [scoreBump]`              |
+| `fetch-photos`                | Fetch photos for places          | `pnpm fetch-photos [--minScore=N] [--limit=N]`           |
+| `fetch-ratings`               | Fetch ratings from Google Places | `pnpm fetch-ratings [--minScore=N] [--limit=N]`          |
+| `recalculate-scores`          | Recalculate place scores         | `pnpm recalculate-scores`                                |
+| `migrate-place-types`         | Migrate place types              | `pnpm migrate-place-types`                               |
+| `generate-types`              | Generate DB types                | `pnpm generate-types`                                    |
+| `clear-osm-cache`             | Clear OSM cache                  | `pnpm clear-osm-cache`                                   |
+| `clear-overture-cache`        | Clear Overture cache             | `pnpm clear-overture-cache`                              |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "analyze-urls": "ts-node src/scripts/analyze-urls.ts",
     "verify-places": "ts-node src/scripts/verify-places.ts",
     "fetch-photos": "ts-node src/scripts/fetch-photos.ts",
+    "fetch-ratings": "ts-node src/scripts/fetch-ratings.ts",
     "clear-osm-cache": "./clear-osm-cache.sh",
     "clear-overture-cache": "./clear-overture-cache.sh",
     "generate-types": "supabase gen types typescript --project-id ydtttobvqajzglvdcqas > src/types/database.ts"

--- a/src/controllers/ratings.controller.ts
+++ b/src/controllers/ratings.controller.ts
@@ -1,0 +1,125 @@
+import { Request, Response } from 'express'
+import { supabase } from '../services/supabase.service'
+import { ratingsFetcherService } from '../services/ratings-fetcher.service'
+import { Place } from '../db/places'
+
+export interface FetchRatingsResponse {
+  results: Array<{
+    placeId: string
+    placeName: string
+    success: boolean
+    rating: number | null
+    ratingCount: number | null
+    googlePlacesId: string | null
+    error?: string
+  }>
+  totalProcessed: number
+  totalSuccess: number
+}
+
+/**
+ * Fetch ratings for places that need them
+ * Filters by minimum score if provided
+ */
+export async function fetchRatings(
+  req: Request,
+  res: Response<FetchRatingsResponse | { error: string }>,
+): Promise<void> {
+  try {
+    const minScore = req.body.minScore ? Number(req.body.minScore) : undefined
+    const limit = req.body.limit ? Number(req.body.limit) : undefined
+
+    if (minScore !== undefined && (isNaN(minScore) || minScore < 0)) {
+      res.status(400).json({ error: 'minScore must be a non-negative number' })
+      return
+    }
+
+    if (limit !== undefined && (isNaN(limit) || limit < 1)) {
+      res.status(400).json({ error: 'limit must be a positive number' })
+      return
+    }
+
+    console.log(`\n⭐ Starting ratings fetch process`)
+    if (minScore !== undefined) {
+      console.log(`📊 Minimum score filter: ${minScore}`)
+    }
+    if (limit !== undefined) {
+      console.log(`🔢 Limit: ${limit} places`)
+    }
+
+    // Get places that need ratings fetched
+    // Either never fetched, or fetched more than 6 months ago
+    const sixMonthsAgo = new Date()
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+
+    let query = supabase
+      .from('places')
+      .select('*')
+      .or(
+        `google_rating_fetched_at.is.null,google_rating_fetched_at.lt.${sixMonthsAgo.toISOString()}`,
+      )
+
+    if (minScore !== undefined) {
+      query = query.gte('score', minScore)
+    }
+
+    // Order by score descending to prioritize higher-scored places
+    query = query.order('score', { ascending: false })
+
+    if (limit !== undefined) {
+      query = query.limit(limit)
+    }
+
+    const { data: placesToProcess, error: queryError } = await query
+
+    if (queryError) {
+      console.error('❌ Error fetching places:', queryError)
+      res.status(500).json({ error: `Database error: ${queryError.message}` })
+      return
+    }
+
+    if (!placesToProcess || placesToProcess.length === 0) {
+      res.status(200).json({
+        results: [],
+        totalProcessed: 0,
+        totalSuccess: 0,
+      })
+      return
+    }
+
+    console.log(`📋 Found ${placesToProcess.length} places to process`)
+
+    const results: FetchRatingsResponse['results'] = []
+
+    // Process places one by one with delay
+    for (let i = 0; i < placesToProcess.length; i++) {
+      const place = placesToProcess[i] as Place
+      console.log(`\n📍 Processing place ${i + 1}/${placesToProcess.length}: ${place.name}`)
+
+      const result = await ratingsFetcherService.fetchRatingsForPlace(place)
+      results.push(result)
+
+      // Add delay between requests (except for the last one)
+      if (i < placesToProcess.length - 1) {
+        await ratingsFetcherService.delay()
+      }
+    }
+
+    const totalSuccess = results.filter((r) => r.success).length
+
+    console.log(`\n✅ Ratings fetch complete!`)
+    console.log(`📊 Processed: ${results.length}`)
+    console.log(`✅ Success: ${totalSuccess}`)
+
+    res.status(200).json({
+      results,
+      totalProcessed: results.length,
+      totalSuccess,
+    })
+  } catch (error) {
+    console.error('❌ Error in fetchRatings:', error)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    res.status(500).json({ error: `Internal server error: ${errorMessage}` })
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { analyzePlaceWebsite, analyzePlaceWikipedia } from './controllers/place-
 import { analyzeUrls } from './controllers/url-analysis.controller'
 import { verifyPlaces } from './controllers/place-verification.controller'
 import { fetchPhotos } from './controllers/photo.controller'
+import { fetchRatings } from './controllers/ratings.controller'
 import { authenticateApiKey } from './middleware/auth.middleware'
 
 const app = express()
@@ -493,6 +494,96 @@ app.post('/api/places/verify', authenticateApiKey, strictLimiter, verifyPlaces)
  *               $ref: '#/components/schemas/Error'
  */
 app.post('/api/places/fetch-photos', authenticateApiKey, fetchPhotos)
+
+/**
+ * @swagger
+ * /api/places/fetch-ratings:
+ *   post:
+ *     summary: Fetch ratings for places from Google Places API
+ *     description: |
+ *       Fetches ratings for places that haven't been fetched yet or were fetched more than 6 months ago.
+ *       Uses existing Google Places ID if available, otherwise searches for it.
+ *       Processes places sequentially with a 1-second delay between requests.
+ *       Can optionally filter by minimum score.
+ *       Adds +2 score bump for places where ratings are collected.
+ *     tags:
+ *       - Places
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               minScore:
+ *                 type: number
+ *                 minimum: 0
+ *                 description: Optional. Only fetch ratings for places with score >= minScore
+ *               limit:
+ *                 type: number
+ *                 minimum: 1
+ *                 description: Optional. Maximum number of places to process
+ *           example:
+ *             minScore: 5
+ *             limit: 50
+ *     responses:
+ *       200:
+ *         description: Successful ratings fetch
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 results:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       placeId:
+ *                         type: string
+ *                         format: uuid
+ *                       placeName:
+ *                         type: string
+ *                       success:
+ *                         type: boolean
+ *                       rating:
+ *                         type: number
+ *                         nullable: true
+ *                       ratingCount:
+ *                         type: number
+ *                         nullable: true
+ *                       googlePlacesId:
+ *                         type: string
+ *                         nullable: true
+ *                       error:
+ *                         type: string
+ *                         nullable: true
+ *                 totalProcessed:
+ *                   type: number
+ *                 totalSuccess:
+ *                   type: number
+ *       400:
+ *         description: Bad request (invalid minScore or limit)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: Unauthorized (missing or invalid API key)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+app.post('/api/places/fetch-ratings', authenticateApiKey, fetchRatings)
 
 /**
  * @swagger

--- a/src/scripts/fetch-ratings.ts
+++ b/src/scripts/fetch-ratings.ts
@@ -1,0 +1,155 @@
+import 'dotenv/config'
+import { supabase } from '../services/supabase.service'
+import { ratingsFetcherService } from '../services/ratings-fetcher.service'
+import { Place } from '../db/places'
+
+interface ProcessStats {
+  processedCount: number
+  successCount: number
+  errorCount: number
+  skippedCount: number
+}
+
+class RatingsFetcher {
+  public readonly stats: ProcessStats
+
+  constructor() {
+    this.stats = {
+      processedCount: 0,
+      successCount: 0,
+      errorCount: 0,
+      skippedCount: 0,
+    }
+  }
+
+  private printProgress(): void {
+    console.log(`\n📊 Progress:`)
+    console.log(`   Processed: ${this.stats.processedCount}`)
+    console.log(`   Success: ${this.stats.successCount}`)
+    console.log(`   Skipped: ${this.stats.skippedCount}`)
+    console.log(`   Errors: ${this.stats.errorCount}`)
+  }
+
+  public async fetchRatingsForPlaces(minScore?: number, limit?: number): Promise<void> {
+    console.log(`\n⭐ Starting ratings fetch process`)
+    if (minScore !== undefined) {
+      console.log(`📊 Minimum score filter: ${minScore}`)
+    }
+    if (limit !== undefined) {
+      console.log(`🔢 Limit: ${limit} places`)
+    }
+
+    // Get places that need ratings fetched
+    // Either never fetched, or fetched more than 6 months ago
+    const sixMonthsAgo = new Date()
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+
+    let query = supabase
+      .from('places')
+      .select('*')
+      .or(
+        `google_rating_fetched_at.is.null,google_rating_fetched_at.lt.${sixMonthsAgo.toISOString()}`,
+      )
+
+    if (minScore !== undefined) {
+      query = query.gte('score', minScore)
+    }
+
+    // Order by score descending to prioritize higher-scored places
+    query = query.order('score', { ascending: false })
+
+    if (limit !== undefined) {
+      query = query.limit(limit)
+    }
+
+    const { data: placesToProcess, error: queryError } = await query
+
+    if (queryError) {
+      console.error('❌ Error fetching places:', queryError)
+      throw queryError
+    }
+
+    if (!placesToProcess || placesToProcess.length === 0) {
+      console.log('✅ No places to process!')
+      return
+    }
+
+    console.log(`📋 Found ${placesToProcess.length} places to process`)
+
+    // Process places one by one with delay
+    for (let i = 0; i < placesToProcess.length; i++) {
+      const place = placesToProcess[i] as Place
+      console.log(`\n📍 Processing place ${i + 1}/${placesToProcess.length}: ${place.name}`)
+
+      try {
+        const result = await ratingsFetcherService.fetchRatingsForPlace(place)
+        this.stats.processedCount++
+
+        if (result.success) {
+          this.stats.successCount++
+        } else if (result.error?.includes('recently')) {
+          this.stats.skippedCount++
+        } else {
+          this.stats.errorCount++
+        }
+
+        // Print progress every 10 places
+        if ((i + 1) % 10 === 0) {
+          this.printProgress()
+        }
+
+        // Add delay between requests (except for the last one)
+        if (i < placesToProcess.length - 1) {
+          await ratingsFetcherService.delay()
+        }
+      } catch (error) {
+        this.stats.processedCount++
+        this.stats.errorCount++
+        console.error(`❌ Error processing place ${place.name}:`, error)
+      }
+    }
+
+    // Final summary
+    console.log(`\n✅ Ratings fetch complete!`)
+    this.printProgress()
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  let minScore: number | undefined
+  let limit: number | undefined
+
+  // Parse command line arguments
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--minScore' && i + 1 < args.length) {
+      minScore = Number(args[i + 1])
+      if (isNaN(minScore) || minScore < 0) {
+        console.error('❌ minScore must be a non-negative number')
+        process.exit(1)
+      }
+      i++
+    } else if (args[i] === '--limit' && i + 1 < args.length) {
+      limit = Number(args[i + 1])
+      if (isNaN(limit) || limit < 1) {
+        console.error('❌ limit must be a positive number')
+        process.exit(1)
+      }
+      i++
+    }
+  }
+
+  const fetcher = new RatingsFetcher()
+
+  try {
+    await fetcher.fetchRatingsForPlaces(minScore, limit)
+  } catch (error) {
+    console.error('❌ Fatal error:', error)
+    process.exit(1)
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+

--- a/src/services/ratings-fetcher.service.ts
+++ b/src/services/ratings-fetcher.service.ts
@@ -1,0 +1,225 @@
+import { Place, updatePlace } from '../db/places'
+import { calculateGeometryCenter } from '../utils/common'
+import { googlePlacesService } from './google-places.service'
+
+export interface RatingsFetchResult {
+  placeId: string
+  placeName: string
+  success: boolean
+  rating: number | null
+  ratingCount: number | null
+  googlePlacesId: string | null
+  error?: string
+}
+
+export class RatingsFetcherService {
+  /**
+   * Check if ratings should be fetched (not fetched or older than 6 months)
+   */
+  private shouldFetchRatings(place: Place): boolean {
+    const fetchedAt = place.google_rating_fetched_at
+
+    // If never fetched, should fetch
+    if (!fetchedAt) {
+      return true
+    }
+
+    // Check if older than 6 months
+    const fetchedDate = new Date(fetchedAt)
+    const sixMonthsAgo = new Date()
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+
+    return fetchedDate < sixMonthsAgo
+  }
+
+  /**
+   * Fetch ratings for a place from Google Places API
+   */
+  public async fetchRatingsForPlace(place: Place): Promise<RatingsFetchResult> {
+    const result: RatingsFetchResult = {
+      placeId: place.id,
+      placeName: place.name || 'Unknown',
+      success: false,
+      rating: null,
+      ratingCount: null,
+      googlePlacesId: null,
+    }
+
+    try {
+      // Check if we should fetch ratings
+      if (!this.shouldFetchRatings(place)) {
+        const fetchedAt = place.google_rating_fetched_at
+        console.log(`⏭️  Skipping ${place.name} - ratings fetched recently (${fetchedAt})`)
+        result.error = 'Ratings fetched recently (less than 6 months ago)'
+        return result
+      }
+
+      // Get coordinates from geometry or location
+      const center = calculateGeometryCenter(place.geometry)
+      const latitude = center?.lat || null
+      const longitude = center?.lon || null
+
+      if (!place.name) {
+        result.error = 'Place has no name'
+        return result
+      }
+
+      console.log(`\n⭐ Fetching ratings for: ${place.name}`)
+      if (latitude !== null && longitude !== null) {
+        console.log(`📍 Location: ${latitude}, ${longitude}`)
+      }
+
+      // Check if place already has a Google Places ID
+      const existingGooglePlacesId = place.google_places_id || null
+
+      const { rating, ratingCount, googlePlacesId } = await googlePlacesService.searchPlaceRatings(
+        place.name,
+        latitude,
+        longitude,
+        existingGooglePlacesId,
+      )
+
+      // If place ID not found, mark as fetched to skip retries
+      if (googlePlacesId === null) {
+        console.log(`❌ Google Place ID not found for: ${place.name}`)
+        result.error = 'Google Place ID not found'
+        // Mark as fetched to avoid repeated attempts
+        await this.markRatingsFetched(place.id, null, null, null)
+        return result
+      }
+
+      // If place ID found but no ratings, mark as fetched to skip retries
+      if (rating === null) {
+        console.log(`❌ No ratings found for: ${place.name}`)
+        result.error = 'No ratings found'
+        result.googlePlacesId = googlePlacesId
+        // Still mark as fetched to avoid repeated attempts (but don't bump score)
+        await this.markRatingsFetched(place.id, null, null, googlePlacesId)
+        return result
+      }
+
+      console.log(`✅ Found rating: ${rating} (${ratingCount || 0} reviews)`)
+
+      // Store ratings, Google Places ID, and bump score (+2)
+      await this.saveRatings(place.id, rating, ratingCount, googlePlacesId)
+
+      result.success = true
+      result.rating = rating
+      result.ratingCount = ratingCount
+      result.googlePlacesId = googlePlacesId
+
+      return result
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      console.error(`❌ Error fetching ratings:`, errorMessage)
+      result.error = errorMessage
+      return result
+    }
+  }
+
+  /**
+   * Save ratings to database and bump score (only if first time collecting ratings)
+   */
+  private async saveRatings(
+    placeId: string,
+    rating: number,
+    ratingCount: number | null,
+    googlePlacesId: string | null,
+  ): Promise<void> {
+    try {
+      // Get current place to check if it already has ratings
+      const { supabase } = await import('../services/supabase.service')
+      const { data: place, error: fetchError } = await supabase
+        .from('places')
+        .select('score, google_rating, enhancement_score')
+        .eq('id', placeId)
+        .single()
+
+      if (fetchError || !place) {
+        console.error(`❌ Error fetching place for score update:`, fetchError)
+        throw fetchError
+      }
+
+      // Only bump score if this is the first time collecting ratings
+      const isFirstTime = !place.google_rating
+      const currentScore = place.score || 0
+      const currentEnhancementScore = place.enhancement_score || 0
+      const newEnhancementScore = isFirstTime ? currentEnhancementScore + 2 : currentEnhancementScore
+      const newScore = isFirstTime ? currentScore + 2 : currentScore
+
+      // Prepare updates
+      const updates: Partial<Place> = {
+        google_rating: rating,
+        google_rating_count: ratingCount,
+        google_rating_fetched_at: new Date().toISOString(),
+        score: newScore,
+        enhancement_score: newEnhancementScore,
+      }
+
+      // Store Google Places ID if we found one and it's different
+      if (googlePlacesId) {
+        updates.google_places_id = googlePlacesId
+      }
+
+      const { error } = await updatePlace(placeId, updates)
+
+      if (error) {
+        console.error(`❌ Error saving ratings:`, error)
+        throw error
+      }
+
+      if (isFirstTime) {
+        console.log(
+          `✅ Saved ratings and bumped scores: ${currentScore} → ${newScore} (+2 total), ${currentEnhancementScore} → ${newEnhancementScore} (+2 enhancement)`,
+        )
+      } else {
+        console.log(
+          `✅ Updated ratings (scores unchanged: ${currentScore} total, ${currentEnhancementScore} enhancement)`,
+        )
+      }
+    } catch (error) {
+      console.error(`❌ Error in saveRatings:`, error)
+      throw error
+    }
+  }
+
+  /**
+   * Mark that ratings have been fetched (even if no ratings found)
+   */
+  private async markRatingsFetched(
+    placeId: string,
+    rating: number | null,
+    ratingCount: number | null,
+    googlePlacesId: string | null,
+  ): Promise<void> {
+    try {
+      const updates: Partial<Place> = {
+        google_rating_fetched_at: new Date().toISOString(),
+      }
+
+      if (rating !== null) {
+        updates.google_rating = rating
+      }
+      if (ratingCount !== null) {
+        updates.google_rating_count = ratingCount
+      }
+      if (googlePlacesId) {
+        updates.google_places_id = googlePlacesId
+      }
+
+      await updatePlace(placeId, updates)
+    } catch (error) {
+      console.error(`❌ Error marking ratings as fetched:`, error)
+      // Don't throw - this is not critical
+    }
+  }
+
+  /**
+   * Add delay between API requests (1 second as requested)
+   */
+  public async delay(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+}
+
+export const ratingsFetcherService = new RatingsFetcherService()

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -110,6 +110,10 @@ export type Database = {
           description: string | null
           enhancement_score: number | null
           geometry: unknown
+          google_places_id: string | null
+          google_rating: number | null
+          google_rating_count: number | null
+          google_rating_fetched_at: string | null
           id: string
           last_enhanced_at: string | null
           last_website_analyzed_at: string | null
@@ -144,6 +148,10 @@ export type Database = {
           description?: string | null
           enhancement_score?: number | null
           geometry?: unknown
+          google_places_id?: string | null
+          google_rating?: number | null
+          google_rating_count?: number | null
+          google_rating_fetched_at?: string | null
           id?: string
           last_enhanced_at?: string | null
           last_website_analyzed_at?: string | null
@@ -178,6 +186,10 @@ export type Database = {
           description?: string | null
           enhancement_score?: number | null
           geometry?: unknown
+          google_places_id?: string | null
+          google_rating?: number | null
+          google_rating_count?: number | null
+          google_rating_fetched_at?: string | null
           id?: string
           last_enhanced_at?: string | null
           last_website_analyzed_at?: string | null


### PR DESCRIPTION
- Introduced a new command `fetch-ratings` to fetch ratings from Google Places API, including options for minimum score and limit.
- Updated README.md with detailed usage instructions and examples for the new command.
- Added a new API endpoint `/api/places/fetch-ratings` to handle ratings fetching.
- Implemented logic to store Google Places ID and update place scores upon first rating fetch.
- Updated database schema to include fields for Google Places ID, rating, and review count.
- Removed unused Google Places photos service as part of the refactor.